### PR TITLE
updated revideo-user-policy json

### DIFF
--- a/parallelized-aws-lambda/README.md
+++ b/parallelized-aws-lambda/README.md
@@ -267,6 +267,7 @@ Note down your access key id and secret access key as you will need them later.
         "Sid": "ECRPermissions",
         "Effect": "Allow",
 		"Action": [
+				"ecr:CreateRepository",
 				"ecr:GetAuthorizationToken",
 				"ecr:BatchCheckLayerAvailability",
 				"ecr:GetDownloadUrlForLayer",


### PR DESCRIPTION
Added "ecr:CreateRepository" permission to the revideo-user-policy JSON in the README for parallelized-aws-lambda.

Previous error message:

An error occurred (AccessDeniedException) when calling the CreateRepository operation: User <arn-user> is not authorized to perform ecr:CreateRepository on resource <arn-repo-ecr> because no identity-based policy allows the ecr:CreateRepository action.
