### PR TITLE
Fix youtube-short example project dimensions

### DIFF
--- a/youtube-shorts/src/project.tsx
+++ b/youtube-shorts/src/project.tsx
@@ -235,7 +235,7 @@ export default makeProject({
   variables: metadata,
   settings: {
     shared: {
-      size: {x: 1920, y: 1080},
+      size: {x: 1080, y: 1920},
     },
   },
 });


### PR DESCRIPTION
The dimensions got accidentally flipped in https://github.com/redotvideo/examples/commit/e368da7cc5c0d86a885539afa0bf2af87c083d66 to be landscape instead of portrait.